### PR TITLE
Clipboard-functional packet data controls

### DIFF
--- a/PSCap/PSCap.csproj
+++ b/PSCap/PSCap.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -24,7 +25,6 @@
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
@@ -37,6 +37,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -46,7 +47,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-NoGame|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -192,9 +193,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\lock_16xLG.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="TODO.txt" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">

--- a/PSCap/PSCapMain.Designer.cs
+++ b/PSCap/PSCapMain.Designer.cs
@@ -31,6 +31,11 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PSCapMain));
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.listView1 = new PSCap.ListViewEx();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.hexLineNumbers = new System.Windows.Forms.TextBox();
+            this.hexDisplay = new System.Windows.Forms.TextBox();
+            this.hexCharDisplay = new System.Windows.Forms.TextBox();
             this.richTextBox1 = new System.Windows.Forms.RichTextBox();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -46,6 +51,7 @@
             this.customizeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.hotkeysToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.eventImageList = new System.Windows.Forms.ImageList(this.components);
             this.toolStripContainer1 = new System.Windows.Forms.ToolStripContainer();
@@ -62,12 +68,11 @@
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.capturePauseButton = new System.Windows.Forms.ToolStripButton();
             this.backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
-            this.hotkeysToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.listView1 = new PSCap.ListViewEx();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.toolStripContainer1.BottomToolStripPanel.SuspendLayout();
             this.toolStripContainer1.ContentPanel.SuspendLayout();
@@ -90,10 +95,76 @@
             // 
             // splitContainer1.Panel2
             // 
+            this.splitContainer1.Panel2.Controls.Add(this.flowLayoutPanel1);
             this.splitContainer1.Panel2.Controls.Add(this.richTextBox1);
             this.splitContainer1.Size = new System.Drawing.Size(771, 291);
             this.splitContainer1.SplitterDistance = 137;
             this.splitContainer1.TabIndex = 2;
+            // 
+            // listView1
+            // 
+            this.listView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.listView1.FullRowSelect = true;
+            this.listView1.Location = new System.Drawing.Point(0, 0);
+            this.listView1.MultiSelect = false;
+            this.listView1.Name = "listView1";
+            this.listView1.ScrollPosition = 0;
+            this.listView1.Size = new System.Drawing.Size(771, 137);
+            this.listView1.TabIndex = 0;
+            this.listView1.UseCompatibleStateImageBehavior = false;
+            this.listView1.onScroll += new System.Windows.Forms.ScrollEventHandler(this.listView1_OnScroll);
+            this.listView1.RetrieveVirtualItem += new System.Windows.Forms.RetrieveVirtualItemEventHandler(this.listView1_RetrieveVirtualItem);
+            this.listView1.SelectedIndexChanged += new System.EventHandler(this.listView1_SelectedIndexChanged);
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Controls.Add(this.hexLineNumbers);
+            this.flowLayoutPanel1.Controls.Add(this.hexDisplay);
+            this.flowLayoutPanel1.Controls.Add(this.hexCharDisplay);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(771, 150);
+            this.flowLayoutPanel1.TabIndex = 1;
+            // 
+            // hexLineNumbers
+            // 
+            this.hexLineNumbers.BackColor = System.Drawing.SystemColors.Control;
+            this.hexLineNumbers.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.hexLineNumbers.Enabled = false;
+            this.hexLineNumbers.Font = new System.Drawing.Font("Courier New", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.hexLineNumbers.Location = new System.Drawing.Point(3, 5);
+            this.hexLineNumbers.Margin = new System.Windows.Forms.Padding(3, 5, 3, 3);
+            this.hexLineNumbers.Multiline = true;
+            this.hexLineNumbers.Name = "hexLineNumbers";
+            this.hexLineNumbers.Size = new System.Drawing.Size(67, 129);
+            this.hexLineNumbers.TabIndex = 0;
+            // 
+            // hexDisplay
+            // 
+            this.hexDisplay.BackColor = System.Drawing.SystemColors.Window;
+            this.hexDisplay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.hexDisplay.Font = new System.Drawing.Font("Courier New", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.hexDisplay.Location = new System.Drawing.Point(73, 3);
+            this.hexDisplay.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
+            this.hexDisplay.Multiline = true;
+            this.hexDisplay.Name = "hexDisplay";
+            this.hexDisplay.ReadOnly = true;
+            this.hexDisplay.Size = new System.Drawing.Size(380, 130);
+            this.hexDisplay.TabIndex = 4;
+            // 
+            // hexCharDisplay
+            // 
+            this.hexCharDisplay.BackColor = System.Drawing.SystemColors.Window;
+            this.hexCharDisplay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.hexCharDisplay.Font = new System.Drawing.Font("Courier New", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.hexCharDisplay.Location = new System.Drawing.Point(453, 3);
+            this.hexCharDisplay.Margin = new System.Windows.Forms.Padding(0, 3, 3, 3);
+            this.hexCharDisplay.Multiline = true;
+            this.hexCharDisplay.Name = "hexCharDisplay";
+            this.hexCharDisplay.ReadOnly = true;
+            this.hexCharDisplay.Size = new System.Drawing.Size(140, 130);
+            this.hexCharDisplay.TabIndex = 2;
             // 
             // richTextBox1
             // 
@@ -200,7 +271,7 @@
             this.optionsToolStripMenuItem});
             this.toolsToolStripMenuItem.Enabled = false;
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(48, 20);
             this.toolsToolStripMenuItem.Text = "&Tools";
             this.toolsToolStripMenuItem.Visible = false;
             // 
@@ -225,10 +296,17 @@
             this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpToolStripMenuItem.Text = "&Help";
             // 
+            // hotkeysToolStripMenuItem
+            // 
+            this.hotkeysToolStripMenuItem.Name = "hotkeysToolStripMenuItem";
+            this.hotkeysToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.hotkeysToolStripMenuItem.Text = "Hotkeys...";
+            this.hotkeysToolStripMenuItem.Click += new System.EventHandler(this.hotkeysToolStripMenuItem_Click);
+            // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
             this.aboutToolStripMenuItem.Text = "&About...";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
@@ -368,28 +446,6 @@
             this.capturePauseButton.Text = "Capture";
             this.capturePauseButton.Click += new System.EventHandler(this.capturePauseButton_Click);
             // 
-            // hotkeysToolStripMenuItem
-            // 
-            this.hotkeysToolStripMenuItem.Name = "hotkeysToolStripMenuItem";
-            this.hotkeysToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.hotkeysToolStripMenuItem.Text = "Hotkeys...";
-            this.hotkeysToolStripMenuItem.Click += new System.EventHandler(this.hotkeysToolStripMenuItem_Click);
-            // 
-            // listView1
-            // 
-            this.listView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.listView1.FullRowSelect = true;
-            this.listView1.Location = new System.Drawing.Point(0, 0);
-            this.listView1.MultiSelect = false;
-            this.listView1.Name = "listView1";
-            this.listView1.ScrollPosition = 0;
-            this.listView1.Size = new System.Drawing.Size(771, 137);
-            this.listView1.TabIndex = 0;
-            this.listView1.UseCompatibleStateImageBehavior = false;
-            this.listView1.onScroll += new System.Windows.Forms.ScrollEventHandler(this.listView1_OnScroll);
-            this.listView1.RetrieveVirtualItem += new System.Windows.Forms.RetrieveVirtualItemEventHandler(this.listView1_RetrieveVirtualItem);
-            this.listView1.SelectedIndexChanged += new System.EventHandler(this.listView1_SelectedIndexChanged);
-            // 
             // PSCapMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -405,6 +461,8 @@
             this.splitContainer1.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.toolStripContainer1.BottomToolStripPanel.ResumeLayout(false);
@@ -457,6 +515,10 @@
         private System.Windows.Forms.ToolStripStatusLabel recordCountLabel;
         private System.ComponentModel.BackgroundWorker backgroundWorker1;
         private System.Windows.Forms.ToolStripMenuItem hotkeysToolStripMenuItem;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.TextBox hexLineNumbers;
+        private System.Windows.Forms.TextBox hexCharDisplay;
+        private System.Windows.Forms.TextBox hexDisplay;
     }
 }
 

--- a/PSCap/PSCapMain.cs
+++ b/PSCap/PSCapMain.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.Design;
 using System.Data;
 using System.Diagnostics;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
@@ -48,7 +49,6 @@ namespace PSCap
         bool followLast = true;
         int loggerId = 0;
 
-        private ByteViewer byteViewer1;
         private UIState currentUIState = UIState.Detached;
 
         public PSCapMain(int loggerId)
@@ -58,15 +58,6 @@ namespace PSCap
 
             // required for hotkey hooking with key modifiers
             this.KeyPreview = true;
-
-            byteViewer1 = new ByteViewer();
-            byteViewer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            byteViewer1.Anchor = AnchorStyles.Left | AnchorStyles.Top;
-            this.byteViewer1.Location = new System.Drawing.Point(0, 0);
-            this.byteViewer1.Name = "byteViewer1";
-            this.byteViewer1.Size = new System.Drawing.Size(771, 150);
-            this.splitContainer1.Panel2.Controls.Add(byteViewer1);
-
             splitContainer1.PerformLayout();
         }
 
@@ -334,6 +325,7 @@ namespace PSCap
                     saveAsToolStripMenuItem.Enabled = false;
                     copyToolStripMenuItem.Enabled = false;
                     openToolStripMenuItem.Enabled = true;
+                    this.displayPacketData(null);
 
                     setCaptureFileName("");
                     return;
@@ -345,6 +337,7 @@ namespace PSCap
                     saveAsToolStripMenuItem.Enabled = false;
                     copyToolStripMenuItem.Enabled = true;
                     openToolStripMenuItem.Enabled = false;
+                    this.displayPacketData(null);
                     return;
                 }
 
@@ -396,7 +389,8 @@ namespace PSCap
 
                     updateCaptureFileState();
                 }
-
+                
+                this.displayPacketData(null);
             });
         }
 
@@ -591,8 +585,7 @@ namespace PSCap
                 followLast = false;
         }
 
-        private void listView1_SelectedIndexChanged(object sender, EventArgs e)
-        {
+        private void listView1_SelectedIndexChanged(object sender, EventArgs e) {
             /*foreach(var s in listView1.SelectedIndices)
             {
                 Console.WriteLine("New selection " + s.ToString());
@@ -602,24 +595,107 @@ namespace PSCap
             richTextBox1.SelectionColor = Color.Green;
             richTextBox1.AppendText("  "); // dont remove this if you want colors
 
-            if (listView1.SelectedIndices.Count == 0)
+            if(listView1.SelectedIndices.Count == 0) {
+                this.displayPacketData(null);
                 richTextBox1.Text = ("No selection");
-            else
-            {
+            }
+            else {
                 RecordGame record = captureFile.getRecord(listView1.SelectedIndices[0]) as RecordGame;
                 GameRecordPacket gameRecord = record.Record as GameRecordPacket;
 
-                string bytes = "";
                 string name = ((PlanetSideMessageType)gameRecord.packet[0]).ToString();
-                foreach (byte b in gameRecord.packet)
-                    bytes += string.Format("{0:X2} ", b);
-
-                byteViewer1.SetBytes(gameRecord.packet.ToArray());
+                string bytes = this.displayPacketData(gameRecord);
 
                 richTextBox1.AppendText(name + "\n");
                 richTextBox1.AppendText(bytes);
 
             }
+        }
+
+        /// <summary>
+        ///     Parse and display hexadecimal strings and character strings from the packet's byte data.
+        /// </summary>
+        /// <param name="gameRecord">
+        ///     The game record packet.
+        /// </param>
+        /// <returns>
+        ///     The hexadecimal data as a string
+        /// </returns>
+        private string displayPacketData(GameRecordPacket gameRecord) {
+            // If there is no record, or no packet data in the record, blank the fields.
+            if(gameRecord == null || gameRecord.packet == null || gameRecord.packet.Count == 0) {
+                this.hexLineNumbers.Text =
+                this.hexDisplay.Text =
+                this.hexCharDisplay.Text = "";
+                return "";
+            }
+
+            // "lineNumbers" keeps track of the number of lines in the "formatted" and "converted" data.
+            // "normal" string is a simple spaced display of each byte turned into hex.
+            // "formatted" string is the display form of the "normal" string.  It's mostly the "normal" string.
+            // "converted" string is what the byte array looks like when converted to char data.
+            StringBuilder lineNumbers = new StringBuilder();
+            StringBuilder normal = new StringBuilder();
+            StringBuilder formatted = new StringBuilder();
+            StringBuilder converted = new StringBuilder();
+            int lineNo = 0;
+
+            // Iterate over packet data bytes.
+            List<byte> array = gameRecord.packet;
+            string newLine = System.Environment.NewLine;
+            for(int entry = 0, byteIndex = 0, byteLength = array.Count; byteIndex < byteLength; byteIndex++) {
+                byte b = array[byteIndex];
+                string decoded = string.Format("{0:X2} ", b);
+                normal.Append(decoded);
+                formatted.Append(decoded);
+                // Lifted directly from ByteViewer.DrawDump (source).
+                char c = Convert.ToChar(b);
+                if(CharIsPrintable(c))
+                    converted.Append(c);
+                else
+                    converted.Append(".");
+
+                entry++;
+                // Once we have displayed sixteen values, start a new line.
+                if(entry == 16) {
+                    formatted.Append(newLine);
+                    converted.Append(newLine);
+                    lineNumbers.Append( (lineNo.ToString().PadLeft(8, '0')) + newLine);
+                    lineNo += 10;
+                    entry = 0;
+                }
+                // An additional space between the first eight values and the latter eight values per line.
+                else if(entry == 8)
+                    formatted.Append(" ");
+                // This is the last line.
+                else if(byteIndex + 1 == byteLength)
+                    lineNumbers.Append( (lineNo.ToString().PadLeft(8, '0')) );
+                
+            }
+
+            // Display resulting data in appropriate fields.
+            this.hexLineNumbers.Text = lineNumbers.ToString();
+            this.hexDisplay.Text = formatted.ToString();
+            this.hexCharDisplay.Text = converted.ToString();
+
+            return normal.ToString();
+        }
+
+        /// <summary>
+        ///     Check if char data meets a set of criteria which defines that it can be properly displayed.
+        /// </summary>
+        /// <param name="c">
+        ///     A character to be tested.
+        /// </param>
+        /// <see cref="System.ComponentModel.Design.ByteViewer.CharIsPrintable"/>
+        /// <returns>
+        ///     True, if the character can be displayed; false, otherwise.
+        /// </returns>
+        private static bool CharIsPrintable(char c) {
+            UnicodeCategory uc = Char.GetUnicodeCategory(c);
+            return (!(uc == UnicodeCategory.Control) || (uc == UnicodeCategory.Format) ||
+                    (uc == UnicodeCategory.LineSeparator) || (uc == UnicodeCategory.ParagraphSeparator) ||
+                    (uc == UnicodeCategory.OtherNotAssigned));
         }
 
         private void exitToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
I replaced the ByteViewer with three Controls that served the same
purposes as the ByteViewer, but allow access to the contained data that
is parsed from the packet.  Existing functionality should not have been
impacted.
