### PR TITLE
Fixed scrolling, plus Mutual Data Selection

### DIFF
--- a/PSCap/PSCap.csproj
+++ b/PSCap/PSCap.csproj
@@ -122,6 +122,9 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Record.cs" />
+    <Compile Include="SharedScrollTextBox.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Util.cs" />
     <EmbeddedResource Include="AboutBox.resx">
       <DependentUpon>AboutBox.cs</DependentUpon>

--- a/PSCap/PSCapMain.Designer.cs
+++ b/PSCap/PSCapMain.Designer.cs
@@ -32,10 +32,10 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PSCapMain));
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.listView1 = new PSCap.ListViewEx();
-            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.panel1 = new System.Windows.Forms.Panel();
             this.hexLineNumbers = new System.Windows.Forms.TextBox();
             this.hexDisplay = new System.Windows.Forms.TextBox();
-            this.hexCharDisplay = new System.Windows.Forms.TextBox();
+            this.hexCharDisplay = new PSCap.SharedScrollTextBox();
             this.richTextBox1 = new System.Windows.Forms.RichTextBox();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -72,7 +72,7 @@
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
-            this.flowLayoutPanel1.SuspendLayout();
+            this.panel1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.toolStripContainer1.BottomToolStripPanel.SuspendLayout();
             this.toolStripContainer1.ContentPanel.SuspendLayout();
@@ -94,8 +94,11 @@
             this.splitContainer1.Panel1.Controls.Add(this.listView1);
             // 
             // splitContainer1.Panel2
-            // 
-            this.splitContainer1.Panel2.Controls.Add(this.flowLayoutPanel1);
+            //
+            this.splitContainer1.Panel2.Controls.Add(this.hexLineNumbers);
+            this.splitContainer1.Panel2.Controls.Add(this.hexDisplay);
+            this.splitContainer1.Panel2.Controls.Add(this.hexCharDisplay);
+            this.splitContainer1.Panel2.Controls.Add(this.panel1);
             this.splitContainer1.Panel2.Controls.Add(this.richTextBox1);
             this.splitContainer1.Size = new System.Drawing.Size(771, 291);
             this.splitContainer1.SplitterDistance = 137;
@@ -116,55 +119,66 @@
             this.listView1.RetrieveVirtualItem += new System.Windows.Forms.RetrieveVirtualItemEventHandler(this.listView1_RetrieveVirtualItem);
             this.listView1.SelectedIndexChanged += new System.EventHandler(this.listView1_SelectedIndexChanged);
             // 
-            // flowLayoutPanel1
+            // panel1
             // 
-            this.flowLayoutPanel1.Controls.Add(this.hexLineNumbers);
-            this.flowLayoutPanel1.Controls.Add(this.hexDisplay);
-            this.flowLayoutPanel1.Controls.Add(this.hexCharDisplay);
-            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(771, 150);
-            this.flowLayoutPanel1.TabIndex = 1;
+            this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.panel1.BackColor = System.Drawing.Color.Transparent;
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill; 
+            this.panel1.Location = new System.Drawing.Point(3, 5);
+            this.panel1.Name = "flowLayoutPanel1";
             // 
             // hexLineNumbers
-            // 
+            //
+            this.hexLineNumbers.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom;
             this.hexLineNumbers.BackColor = System.Drawing.SystemColors.Control;
             this.hexLineNumbers.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.hexLineNumbers.Enabled = false;
             this.hexLineNumbers.Font = new System.Drawing.Font("Courier New", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.hexLineNumbers.Location = new System.Drawing.Point(3, 5);
-            this.hexLineNumbers.Margin = new System.Windows.Forms.Padding(3, 5, 3, 3);
             this.hexLineNumbers.Multiline = true;
             this.hexLineNumbers.Name = "hexLineNumbers";
-            this.hexLineNumbers.Size = new System.Drawing.Size(67, 129);
+            this.hexLineNumbers.Size = new System.Drawing.Size(67, 130);
             this.hexLineNumbers.TabIndex = 0;
             // 
             // hexDisplay
             // 
+            this.hexDisplay.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom;
             this.hexDisplay.BackColor = System.Drawing.SystemColors.Window;
             this.hexDisplay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.hexDisplay.Font = new System.Drawing.Font("Courier New", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.hexDisplay.Location = new System.Drawing.Point(73, 3);
-            this.hexDisplay.Margin = new System.Windows.Forms.Padding(0, 3, 0, 3);
+            this.hexDisplay.HideSelection = false;
+            this.hexDisplay.KeyDown += new System.Windows.Forms.KeyEventHandler(this.hexDisplay_onKeyPress);
+            this.hexDisplay.Location = new System.Drawing.Point(70, 5);
+            this.hexDisplay.MouseDown += new System.Windows.Forms.MouseEventHandler(this.selection_MouseDown);
+            this.hexDisplay.MouseMove += new System.Windows.Forms.MouseEventHandler(this.hexDisplay_onSelection);
+            this.hexDisplay.MouseUp += new System.Windows.Forms.MouseEventHandler(this.selection_MouseUp);
             this.hexDisplay.Multiline = true;
             this.hexDisplay.Name = "hexDisplay";
             this.hexDisplay.ReadOnly = true;
-            this.hexDisplay.Size = new System.Drawing.Size(380, 130);
+            this.hexDisplay.Size = new System.Drawing.Size(402, 130);
             this.hexDisplay.TabIndex = 4;
             // 
             // hexCharDisplay
             // 
+            this.hexCharDisplay.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom;
             this.hexCharDisplay.BackColor = System.Drawing.SystemColors.Window;
             this.hexCharDisplay.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.hexCharDisplay.Font = new System.Drawing.Font("Courier New", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.hexCharDisplay.Location = new System.Drawing.Point(453, 3);
-            this.hexCharDisplay.Margin = new System.Windows.Forms.Padding(0, 3, 3, 3);
+            this.hexCharDisplay.HideSelection = false;
+            this.hexCharDisplay.KeyDown += new System.Windows.Forms.KeyEventHandler(this.hexCharDisplay_onKeyPress);
+            this.hexCharDisplay.Location = new System.Drawing.Point(471, 5);
+            this.hexCharDisplay.MouseDown += new System.Windows.Forms.MouseEventHandler(this.selection_MouseDown);
+            this.hexCharDisplay.MouseMove += new System.Windows.Forms.MouseEventHandler(this.hexCharDisplay_onSelection);
+            this.hexCharDisplay.MouseUp += new System.Windows.Forms.MouseEventHandler(this.selection_MouseUp);
+            this.hexCharDisplay.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.ignoreMouseWheel);
             this.hexCharDisplay.Multiline = true;
+            this.hexCharDisplay.TextChanged += new System.EventHandler(this.hexCharDisplay_TextChanged);
             this.hexCharDisplay.Name = "hexCharDisplay";
             this.hexCharDisplay.ReadOnly = true;
             this.hexCharDisplay.Size = new System.Drawing.Size(140, 130);
             this.hexCharDisplay.TabIndex = 2;
+            this.hexCharDisplay.linkTextbox(this.hexLineNumbers);
+            this.hexCharDisplay.linkTextbox(this.hexDisplay);
             // 
             // richTextBox1
             // 
@@ -461,8 +475,8 @@
             this.splitContainer1.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
-            this.flowLayoutPanel1.ResumeLayout(false);
-            this.flowLayoutPanel1.PerformLayout();
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.toolStripContainer1.BottomToolStripPanel.ResumeLayout(false);
@@ -482,7 +496,7 @@
 
         #endregion
         private System.Windows.Forms.SplitContainer splitContainer1;
-        private ListViewEx listView1;
+        private PSCap.ListViewEx listView1;
         private System.Windows.Forms.MenuStrip menuStrip1;
         private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem;
@@ -515,10 +529,10 @@
         private System.Windows.Forms.ToolStripStatusLabel recordCountLabel;
         private System.ComponentModel.BackgroundWorker backgroundWorker1;
         private System.Windows.Forms.ToolStripMenuItem hotkeysToolStripMenuItem;
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.TextBox hexLineNumbers;
-        private System.Windows.Forms.TextBox hexCharDisplay;
         private System.Windows.Forms.TextBox hexDisplay;
+        private PSCap.SharedScrollTextBox hexCharDisplay;
     }
 }
 

--- a/PSCap/SharedScrollTextBox.cs
+++ b/PSCap/SharedScrollTextBox.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace PSCap {
+    /// <summary>
+    ///     Textbox that allows for synchronized scrolling of other textboxes
+    /// </summary>
+    public class SharedScrollTextBox : TextBox {
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wp, IntPtr lp);
+
+        private List<TextBox> buddies;
+
+        public SharedScrollTextBox() {
+            this.buddies = new List<TextBox>();
+        }
+
+        public bool linkTextbox(TextBox box) {
+            if(!this.buddies.Contains(box)) {
+                this.buddies.Add(box);
+                return true;
+            }
+            return false;
+        }
+
+        public bool removeTextbox(TextBox box) {
+            return this.buddies.Remove(box) == true;
+        }
+
+        /// <summary>
+        ///     Coordinate TextBox scrolling with buddies
+        /// </summary>
+        /// <param name="m">
+        ///     The incoming Message
+        /// </param>
+        // stackoverflow.com/questions/3823188/how-can-i-sync-the-scrolling-of-two-multiline-textboxes
+        protected override void WndProc(ref Message m) {
+            base.WndProc(ref m);
+            if((m.Msg == 0x115 || m.Msg == 0x20a) && this.buddies.Count > 0) {
+                foreach(TextBox tbox in this.buddies)
+                    SendMessage(tbox.Handle, m.Msg, m.WParam, m.LParam);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I synchronized the scrolling between the three TextBox controls that were simulating ByteViewer functionality.  The Scrollbar is owned by the right-most Control but it sends its messages to its neighboring Controls.  Additionally, I had to rig the three controls to handle key presses and mouse dragging and maintain line number alignment, so I also included code that allows equivalent parsed hexadecimal data and parsed character data to become highlighted at the same time.

The mouse wheel events are disabled because they would only work properly for a Control that owns a ScrollBar.  Even if I could calculate the proper caret offsets, the mouse wheel would only work on one of the three Controls.

The caret does not perfectly simulate normal Shift-selection operations in all cases but the cases where its behavior very obviously breaks from normal operations should be uncommon.

After the key press selection handler, the original event has to be consumed.  I do not like this but do not have a way of passing on the event data without causing the caret position to misalign or compromising the event data and its future handling.  This should probably be changed in the future. 
