### PR TITLE
Absolute timestamp

### DIFF
--- a/PSCap/App.config
+++ b/PSCap/App.config
@@ -1,6 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="PSCap.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
+    <userSettings>
+        <PSCap.Properties.Settings>
+            <setting name="Setting" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="AbsoluteTimeStamp" serializeAs="String">
+                <value>False</value>
+            </setting>
+        </PSCap.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/PSCap/App.config
+++ b/PSCap/App.config
@@ -14,7 +14,7 @@
                 <value />
             </setting>
             <setting name="AbsoluteTimeStamp" serializeAs="String">
-                <value>False</value>
+                <value>True</value>
             </setting>
         </PSCap.Properties.Settings>
     </userSettings>

--- a/PSCap/PSCap.csproj
+++ b/PSCap/PSCap.csproj
@@ -112,6 +112,12 @@
     <Compile Include="PipeServer.cs" />
     <Compile Include="PlanetSideControlPacketOpcode.cs" />
     <Compile Include="PlanetSideGamePacketOpcode.cs" />
+    <Compile Include="Preferences.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Preferences.Designer.cs">
+      <DependentUpon>Preferences.cs</DependentUpon>
+    </Compile>
     <Compile Include="ProcessCollectable.cs" />
     <Compile Include="ProcessScanner.cs" />
     <Compile Include="ListViewEx.cs">
@@ -148,6 +154,9 @@
     <EmbeddedResource Include="HotkeysDialog.resx">
       <DependentUpon>HotkeysDialog.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Preferences.resx">
+      <DependentUpon>Preferences.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="ProgressDialog.resx">
       <DependentUpon>ProgressDialog.cs</DependentUpon>
     </EmbeddedResource>
@@ -175,7 +184,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Image1.bmp" />

--- a/PSCap/PSCapMain.Designer.cs
+++ b/PSCap/PSCapMain.Designer.cs
@@ -31,6 +31,8 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PSCapMain));
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.listView1 = new PSCap.ListViewEx();
+            this.hexDump = new PSCap.HexDump();
             this.richTextBox1 = new System.Windows.Forms.RichTextBox();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -63,8 +65,7 @@
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.capturePauseButton = new System.Windows.Forms.ToolStripButton();
             this.backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
-            this.listView1 = new PSCap.ListViewEx();
-            this.hexDump = new PSCap.HexDump();
+            this.preferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -96,6 +97,33 @@
             this.splitContainer1.Size = new System.Drawing.Size(771, 291);
             this.splitContainer1.SplitterDistance = 137;
             this.splitContainer1.TabIndex = 2;
+            // 
+            // listView1
+            // 
+            this.listView1.AllowColumnReorder = true;
+            this.listView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.listView1.FullRowSelect = true;
+            this.listView1.Location = new System.Drawing.Point(0, 0);
+            this.listView1.MultiSelect = false;
+            this.listView1.Name = "listView1";
+            this.listView1.ScrollPosition = 0;
+            this.listView1.Size = new System.Drawing.Size(771, 137);
+            this.listView1.TabIndex = 0;
+            this.listView1.UseCompatibleStateImageBehavior = false;
+            this.listView1.onScroll += new System.Windows.Forms.ScrollEventHandler(this.listView1_OnScroll);
+            this.listView1.RetrieveVirtualItem += new System.Windows.Forms.RetrieveVirtualItemEventHandler(this.listView1_RetrieveVirtualItem);
+            this.listView1.SelectedIndexChanged += new System.EventHandler(this.listView1_SelectedIndexChanged);
+            // 
+            // hexDump
+            // 
+            this.hexDump.Bytes = null;
+            this.hexDump.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.hexDump.Location = new System.Drawing.Point(0, 0);
+            this.hexDump.Margin = new System.Windows.Forms.Padding(3, 3, 5, 3);
+            this.hexDump.Name = "hexDump";
+            this.hexDump.Padding = new System.Windows.Forms.Padding(1);
+            this.hexDump.Size = new System.Drawing.Size(771, 150);
+            this.hexDump.TabIndex = 1;
             // 
             // richTextBox1
             // 
@@ -182,7 +210,8 @@
             // editToolStripMenuItem
             // 
             this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.copyToolStripMenuItem});
+            this.copyToolStripMenuItem,
+            this.preferencesToolStripMenuItem});
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
             this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
             this.editToolStripMenuItem.Text = "&Edit";
@@ -191,7 +220,7 @@
             // 
             this.copyToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(133, 22);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.copyToolStripMenuItem.Text = "Metadata...";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
             // 
@@ -202,7 +231,7 @@
             this.optionsToolStripMenuItem});
             this.toolsToolStripMenuItem.Enabled = false;
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(48, 20);
             this.toolsToolStripMenuItem.Text = "&Tools";
             this.toolsToolStripMenuItem.Visible = false;
             // 
@@ -377,32 +406,12 @@
             this.capturePauseButton.Text = "Capture";
             this.capturePauseButton.Click += new System.EventHandler(this.capturePauseButton_Click);
             // 
-            // listView1
+            // preferencesToolStripMenuItem
             // 
-            this.listView1.AllowColumnReorder = true;
-            this.listView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.listView1.FullRowSelect = true;
-            this.listView1.Location = new System.Drawing.Point(0, 0);
-            this.listView1.MultiSelect = false;
-            this.listView1.Name = "listView1";
-            this.listView1.ScrollPosition = 0;
-            this.listView1.Size = new System.Drawing.Size(771, 137);
-            this.listView1.TabIndex = 0;
-            this.listView1.UseCompatibleStateImageBehavior = false;
-            this.listView1.onScroll += new System.Windows.Forms.ScrollEventHandler(this.listView1_OnScroll);
-            this.listView1.RetrieveVirtualItem += new System.Windows.Forms.RetrieveVirtualItemEventHandler(this.listView1_RetrieveVirtualItem);
-            this.listView1.SelectedIndexChanged += new System.EventHandler(this.listView1_SelectedIndexChanged);
-            // 
-            // hexDump
-            // 
-            this.hexDump.Bytes = null;
-            this.hexDump.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.hexDump.Location = new System.Drawing.Point(0, 0);
-            this.hexDump.Margin = new System.Windows.Forms.Padding(3, 3, 5, 3);
-            this.hexDump.Name = "hexDump";
-            this.hexDump.Padding = new System.Windows.Forms.Padding(1);
-            this.hexDump.Size = new System.Drawing.Size(771, 150);
-            this.hexDump.TabIndex = 1;
+            this.preferencesToolStripMenuItem.Name = "preferencesToolStripMenuItem";
+            this.preferencesToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.preferencesToolStripMenuItem.Text = "Preferences";
+            this.preferencesToolStripMenuItem.Click += new System.EventHandler(this.preferencesToolStripMenuItem_Click);
             // 
             // PSCapMain
             // 
@@ -475,6 +484,7 @@
         private System.ComponentModel.BackgroundWorker backgroundWorker1;
         private System.Windows.Forms.ToolStripMenuItem hotkeysToolStripMenuItem;
         private HexDump hexDump;
+        private System.Windows.Forms.ToolStripMenuItem preferencesToolStripMenuItem;
     }
 }
 

--- a/PSCap/PSCapMain.cs
+++ b/PSCap/PSCapMain.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using PSCap.Properties;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Design;
@@ -15,7 +16,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace PSCap
-{ 
+{
     public partial class PSCapMain : Form
     {
         enum DisableProcessSelectionReason
@@ -48,6 +49,8 @@ namespace PSCap
         bool followLast = true;
         int loggerId = 0;
 
+        DateTime unixDate = new DateTime(1970, 1, 1, CultureInfo.CurrentCulture.Calendar);
+
         private UIState currentUIState = UIState.Detached;
 
         public PSCapMain(int loggerId)
@@ -78,7 +81,7 @@ namespace PSCap
                 MessageBox.Show("Failed to create log file: " + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
-            scanner.ProcessListUpdate += new EventHandler<Process []>(processList_update);
+            scanner.ProcessListUpdate += new EventHandler<Process[]>(processList_update);
             captureLogic.AttachedProcessExited += new AttachedProcessExited(attachedProcessExited);
             captureLogic.NewEvent += new NewEventCallback(newUIEvent);
             captureLogic.OnNewRecord += new NewGameRecord(newRecord);
@@ -100,30 +103,30 @@ namespace PSCap
 
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)
         {
-            if (e.CloseReason == CloseReason.ApplicationExitCall)
+            if(e.CloseReason == CloseReason.ApplicationExitCall)
                 return;
 
             // TODO: handle the cases where we are attached, capturing, or have an unsaved capture
-            if (captureFile != null && captureFile.isModified())
+            if(captureFile != null && captureFile.isModified())
             {
                 DialogResult result = MessageBox.Show("You have an unsaved capture file. Would you like to save it before exiting?",
                     "Save capture file", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning);
 
-                if (result == DialogResult.Yes)
+                if(result == DialogResult.Yes)
                 {
-                    if (captureLogic.isCapturing())
+                    if(captureLogic.isCapturing())
                         captureLogic.stopCapture();
 
                     bool canceled;
                     saveCaptureFile(out canceled);
 
-                    if (canceled)
+                    if(canceled)
                     {
                         e.Cancel = true;
                     }
 
                 }
-                else if (result == DialogResult.Cancel)
+                else if(result == DialogResult.Cancel)
                 {
                     e.Cancel = true;
                 }
@@ -143,7 +146,7 @@ namespace PSCap
             switch(keyData)
             {
                 case Keys.F9:
-                    if (capturePauseButton.Enabled)
+                    if(capturePauseButton.Enabled)
                         capturePauseButton_Click(this, new EventArgs());
                     return true;
                 default:
@@ -179,7 +182,7 @@ namespace PSCap
         {
             List<Record> newItems = new List<Record>(recs.Count);
 
-            foreach (GameRecord gameRec in recs)
+            foreach(GameRecord gameRec in recs)
             {
                 Record rec = Record.Factory.Create(RecordType.GAME);
 
@@ -191,12 +194,12 @@ namespace PSCap
                         gameRecord.setRecord(record);
 
                         /// XXX: nasty hack to prevent password disclosures
-                        byte [] sensitive = { 0x00, 0x09, 0x00, 0x00, 0x01, 0x03 };
+                        byte[] sensitive = { 0x00, 0x09, 0x00, 0x00, 0x01, 0x03 };
                         int i = 0;
 
                         for(i = 0; i < record.packet.Count && i < sensitive.Length; i++)
                         {
-                            if (record.packet[i] != sensitive[i])
+                            if(record.packet[i] != sensitive[i])
                                 break;
                         }
 
@@ -283,7 +286,7 @@ namespace PSCap
         {
             this.SafeInvoke(delegate
             {
-                if (list.Length == 0)
+                if(list.Length == 0)
                 {
                     disableProcessSelection(DisableProcessSelectionReason.NoInstances);
                     return;
@@ -293,13 +296,13 @@ namespace PSCap
                 // clear list, refill it, select first item, enable selection
                 toolStripInstance.Items.Clear();
 
-                foreach (Process p in list)
+                foreach(Process p in list)
                 {
                     toolStripInstance.Items.Add(new ProcessCollectable(p));
                 }
 
                 // select the last item as a convienience
-                if (lastSelectedInstanceIndex < list.Length && lastSelectedInstanceIndex >= 0)
+                if(lastSelectedInstanceIndex < list.Length && lastSelectedInstanceIndex >= 0)
                     toolStripInstance.SelectedIndex = lastSelectedInstanceIndex;
                 else
                     toolStripInstance.SelectedIndex = 0;
@@ -330,7 +333,7 @@ namespace PSCap
         {
             this.SafeInvoke(delegate
             {
-                if (captureFile == null)
+                if(captureFile == null)
                 {
                     saveToolStripMenuItem.Enabled = false;
                     saveAsToolStripMenuItem.Enabled = false;
@@ -342,7 +345,7 @@ namespace PSCap
                     return;
                 }
 
-                if (currentUIState == UIState.Capturing)
+                if(currentUIState == UIState.Capturing)
                 {
                     saveToolStripMenuItem.Enabled = false;
                     saveAsToolStripMenuItem.Enabled = false;
@@ -355,7 +358,7 @@ namespace PSCap
 
                 string filename = Path.GetFileName(captureFile.getCaptureFilename());
 
-                if (captureFile.isModified())
+                if(captureFile.isModified())
                 {
                     saveToolStripMenuItem.Enabled = true;
                     filename += " (modified)";
@@ -381,7 +384,7 @@ namespace PSCap
                 // must be set before
                 captureFile = cap;
 
-                if (cap == null)
+                if(cap == null)
                 {
                     // set the estimate before updating the record count
                     setRecordSizeEstimate(0);
@@ -393,7 +396,7 @@ namespace PSCap
                 {
                     ulong estimatedSize = 0;
 
-                    foreach (Record r in cap.getRecords())
+                    foreach(Record r in cap.getRecords())
                         estimatedSize += r.size;
 
                     setRecordSizeEstimate(estimatedSize);
@@ -411,10 +414,10 @@ namespace PSCap
             this.SafeInvoke(delegate
             {
                 listView1.SetVirtualListSize(count);
-                if (followLast)
+                if(followLast)
                     scrollToEnd();
 
-                if (count == 0)
+                if(count == 0)
                 {
                     recordCountLabel.Visible = false;
                     toolStripStatus.BorderSides = ToolStripStatusLabelBorderSides.None;
@@ -435,7 +438,7 @@ namespace PSCap
         {
             this.SafeInvoke(delegate
             {
-                if (string.Empty == name)
+                if(string.Empty == name)
                     captureFileLabel.Text = "No capture file";
                 else
                     captureFileLabel.Text = name;
@@ -446,7 +449,7 @@ namespace PSCap
         {
             currentUIState = state;
 
-            switch (state)
+            switch(state)
             {
                 case UIState.Detached:
                     Log.Info("UIState Detached");
@@ -493,7 +496,7 @@ namespace PSCap
                         capturePauseButton.Image = Properties.Resources.StatusAnnotations_Play_16xLG_color;
                         capturePauseButton.Text = "Capture";
                         capturePauseButton.Enabled = true;
-                        
+
                         toolStripAttachButton.Text = "Detach";
                         toolStripAttachButton.Enabled = true;
 
@@ -548,12 +551,10 @@ namespace PSCap
                     listView1.EnsureVisible(listView1.Items.Count - 1);
                 });
         }
-        
+
         private void listView1_RetrieveVirtualItem(object sender, RetrieveVirtualItemEventArgs e)
         {
-            RecordGame i = captureFile.getRecord(e.ItemIndex) as RecordGame;
-
-            double time = i.getSecondsSinceStart((uint)captureFile.getStartTime());
+            RecordGame i = captureFile.getRecord(e.ItemIndex) as RecordGame;            
             GameRecordPacket record = i.Record as GameRecordPacket;
 
             string recordName = record.packetDestination == GameRecordPacket.PacketDestination.Client ? "Received Packet" : "Sent Packet";
@@ -565,9 +566,22 @@ namespace PSCap
 
             // plus 1 to skip internal metadata record
             row[0] = (e.ItemIndex + 1).ToString();
-            row[1] = string.Format("{0:0.000000}", time);
+
+            string timestamp;
+            if(Settings.Default.AbsoluteTimeStamp)
+            {
+                ulong recordTimeInSeconds = captureFile.getStartTime() + (i.Record.getRecordTime() / 1000000);
+                DateTime recordTimestamp = unixDate.Add(TimeSpan.FromSeconds(recordTimeInSeconds)).ToLocalTime();
+                timestamp = recordTimestamp.ToString("h:mm:ss");
+            }
+            else
+            {
+                double time = i.getSecondsSinceStart((uint)captureFile.getStartTime());
+                timestamp = string.Format("{0:0.000000}", time);
+            }
+            row[1] = timestamp;
             row[2] = recordName;
-            
+
             row[5] = record.packet.Count.ToString();
 
             string packetName = "";
@@ -596,9 +610,9 @@ namespace PSCap
                     packetType = "Game";
                     backColor = Color.FromArgb(200, 240, 220);
                 }
-                    
+
             }
-            
+
             row[3] = packetType;
             row[4] = packetName;
 
@@ -610,25 +624,26 @@ namespace PSCap
         private void listView1_OnScroll(object sender, ScrollEventArgs e)
         {
             int itemHeight;
-            
-            if (listView1.VirtualListSize == 0)
+
+            if(listView1.VirtualListSize == 0)
                 itemHeight = 0;
             else
                 itemHeight = listView1.GetItemRect(0).Height;
 
-            if (itemHeight == 0) // bad!
+            if(itemHeight == 0) // bad!
                 return;
 
             // mad hax
             int itemsDisplayed = listView1.DisplayRectangle.Height / itemHeight;
-            
-            if (e.NewValue + itemsDisplayed >= listView1.VirtualListSize)
+
+            if(e.NewValue + itemsDisplayed >= listView1.VirtualListSize)
                 followLast = true;
             else
                 followLast = false;
         }
 
-        private void listView1_SelectedIndexChanged(object sender, EventArgs e) {
+        private void listView1_SelectedIndexChanged(object sender, EventArgs e)
+        {
             /*foreach(var s in listView1.SelectedIndices)
             {
                 Console.WriteLine("New selection " + s.ToString());
@@ -638,11 +653,13 @@ namespace PSCap
             //richTextBox1.SelectionColor = Color.Green;
             //richTextBox1.AppendText("  "); // dont remove this if you want colors
 
-            if(listView1.SelectedIndices.Count == 0) {
+            if(listView1.SelectedIndices.Count == 0)
+            {
                 this.hexDump.Bytes = null;
                 //richTextBox1.Text = ("No selection");
             }
-            else {
+            else
+            {
                 RecordGame record = captureFile.getRecord(listView1.SelectedIndices[0]) as RecordGame;
                 GameRecordPacket gameRecord = record.Record as GameRecordPacket;
 
@@ -655,7 +672,7 @@ namespace PSCap
             }
         }
 
-      
+
 
         private void exitToolStripMenuItem_Click(object sender, EventArgs e)
         {
@@ -676,12 +693,12 @@ namespace PSCap
                     DialogResult result = MessageBox.Show("You have an unsaved capture file. Would you like to save it before starting a new capture?",
                         "Save capture file", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning);
 
-                    if (result == DialogResult.Yes)
+                    if(result == DialogResult.Yes)
                     {
-                        if (!saveCaptureFile())
+                        if(!saveCaptureFile())
                             return;
                     }
-                    else if (result == DialogResult.Cancel)
+                    else if(result == DialogResult.Cancel)
                         return;
                 }
 
@@ -703,7 +720,7 @@ namespace PSCap
                 return;
             }
 
-            switch (evt)
+            switch(evt)
             {
                 case EventNotification.Attached:
                     enterUIState(UIState.Attached);
@@ -762,7 +779,7 @@ namespace PSCap
 
                 return true;
             }
-            catch (IOException e)
+            catch(IOException e)
             {
                 Log.Debug("Failed to save capture file: {0}", e.Message);
                 MessageBox.Show(e.Message,
@@ -775,8 +792,8 @@ namespace PSCap
         {
             Log.Info("Save capture file");
 
-            if (captureFile.isFirstSave())
-                if (!showEditMetadata())
+            if(captureFile.isFirstSave())
+                if(!showEditMetadata())
                 {
                     canceled = true;
                     return false;
@@ -793,7 +810,7 @@ namespace PSCap
 
             DialogResult result = saveFile.ShowDialog();
 
-            if (result == DialogResult.OK)
+            if(result == DialogResult.OK)
             {
                 return doSaveCaptureFile(saveFile.FileName);
             }
@@ -818,7 +835,7 @@ namespace PSCap
             }
             else
             {
-                if (!isProcessSelected())
+                if(!isProcessSelected())
                 {
                     Trace.Assert(false, "Attemped to attach without first selecting a process");
                     return;
@@ -829,7 +846,7 @@ namespace PSCap
                 ProcessCollectable targetProcess = new ProcessCollectable(Process.GetCurrentProcess());
 #endif
 
-                if (targetProcess == null)
+                if(targetProcess == null)
                 {
                     MessageBox.Show("Target process target was NULL", "Unknown Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
@@ -840,7 +857,7 @@ namespace PSCap
                 captureLogic.attach(targetProcess,
                     (okay, attachResult, message) =>
                     {
-                        if (okay)
+                        if(okay)
                         {
                             enterUIState(UIState.Attached);
                             return;
@@ -848,12 +865,12 @@ namespace PSCap
 
                         enterUIState(UIState.Detached);
 
-                        if (attachResult == AttachResult.PipeServerStartup)
+                        if(attachResult == AttachResult.PipeServerStartup)
                         {
                             DialogResult res = MessageBox.Show(message + Environment.NewLine + "Would you like to end the offending process?"
                                 , "Failed to Attach", MessageBoxButtons.YesNo, MessageBoxIcon.Error);
 
-                            if (res == DialogResult.Yes)
+                            if(res == DialogResult.Yes)
                             {
                                 targetProcess.Process.Refresh();
 
@@ -869,13 +886,13 @@ namespace PSCap
                             MessageBox.Show(message, "Failed to Attach", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     });
-                    
+
             }
         }
 
         private void saveToolStripMenuItem_Click(object sender, EventArgs evt)
         {
-            if (captureFile.isFirstSave())
+            if(captureFile.isFirstSave())
                 saveCaptureFile();
             else
                 doSaveCaptureFile(captureFile.getCaptureFilename());
@@ -888,29 +905,29 @@ namespace PSCap
 
         private async void openCaptureFile(string filename)
         {
-            if (captureFile != null && captureFile.isModified())
+            if(captureFile != null && captureFile.isModified())
             {
                 DialogResult result = MessageBox.Show("You have an unsaved capture file. Would you like to save it before opening capture?",
                     "Save capture file", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning);
 
-                if (result == DialogResult.Yes)
+                if(result == DialogResult.Yes)
                 {
-                    if (!saveCaptureFile())
+                    if(!saveCaptureFile())
                         return;
                 }
-                else if (result == DialogResult.Cancel)
+                else if(result == DialogResult.Cancel)
                     return;
             }
 
             Log.Info("Open capture");
 
-            if (filename == "")
+            if(filename == "")
             {
                 OpenFileDialog openFile = new OpenFileDialog();
                 openFile.AddExtension = true;
                 openFile.Filter = "Game Capture Files (*.gcap)|*.gcap|All Files (*.*)|*.*";
 
-                if (openFile.ShowDialog() == DialogResult.OK)
+                if(openFile.ShowDialog() == DialogResult.OK)
                 {
                     filename = openFile.FileName;
                 }
@@ -919,7 +936,7 @@ namespace PSCap
                     return;
                 }
             }
-           
+
             BackgroundWorker worker = new BackgroundWorker();
             ProgressDialog progress = new ProgressDialog("Loading capture file");
             progress.ProgressTemplate("Loading records {value}/{max}...");
@@ -934,7 +951,7 @@ namespace PSCap
                     CaptureFile newCapFile = CaptureFile.Factory.FromFile(filename, this, progress);
                     setCaptureFile(newCapFile);
                 }
-                catch (InvalidCaptureFileException e)
+                catch(InvalidCaptureFileException e)
                 {
                     Log.Debug("Failed to open capture file: {0}", e.Message);
                     MessageBox.Show(e.Message, "Could not open capture file",
@@ -964,7 +981,7 @@ namespace PSCap
             EditMetadata editMeta = new EditMetadata(captureFile);
             DialogResult result = editMeta.ShowDialog(this);
 
-            if (result == DialogResult.OK)
+            if(result == DialogResult.OK)
             {
                 captureFile.setCaptureName(editMeta.CaptureNameResult);
                 captureFile.setCaptureDescription(editMeta.DescriptionResult);
@@ -973,7 +990,7 @@ namespace PSCap
 
                 return true;
             }
-            
+
             return false;
         }
 
@@ -992,13 +1009,19 @@ namespace PSCap
         {
             string[] files = (string[])e.Data.GetData(DataFormats.FileDrop, false);
 
-            if (files.Length > 0)
+            if(files.Length > 0)
                 openCaptureFile(files[0]);
         }
 
         private void PSCapMain_DragEnter(object sender, DragEventArgs e)
         {
-            if (e.Data.GetDataPresent(DataFormats.FileDrop)) e.Effect = DragDropEffects.Copy;
+            if(e.Data.GetDataPresent(DataFormats.FileDrop)) e.Effect = DragDropEffects.Copy;
+        }
+
+        private void preferencesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            Preferences preferences = new Preferences();
+            DialogResult result = preferences.ShowDialog(this); // Don't really care about result.
         }
     }
 }

--- a/PSCap/Preferences.Designer.cs
+++ b/PSCap/Preferences.Designer.cs
@@ -36,6 +36,8 @@
             // AbsoluteTimeStampCbx
             // 
             this.AbsoluteTimeStampCbx.AutoSize = true;
+            this.AbsoluteTimeStampCbx.Checked = true;
+            this.AbsoluteTimeStampCbx.CheckState = System.Windows.Forms.CheckState.Checked;
             this.AbsoluteTimeStampCbx.Location = new System.Drawing.Point(12, 12);
             this.AbsoluteTimeStampCbx.Name = "AbsoluteTimeStampCbx";
             this.AbsoluteTimeStampCbx.Size = new System.Drawing.Size(121, 17);

--- a/PSCap/Preferences.Designer.cs
+++ b/PSCap/Preferences.Designer.cs
@@ -1,0 +1,88 @@
+﻿namespace PSCap
+{
+    partial class Preferences
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.AbsoluteTimeStampCbx = new System.Windows.Forms.CheckBox();
+            this.CancelButton = new System.Windows.Forms.Button();
+            this.OkButton = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // AbsoluteTimeStampCbx
+            // 
+            this.AbsoluteTimeStampCbx.AutoSize = true;
+            this.AbsoluteTimeStampCbx.Location = new System.Drawing.Point(12, 12);
+            this.AbsoluteTimeStampCbx.Name = "AbsoluteTimeStampCbx";
+            this.AbsoluteTimeStampCbx.Size = new System.Drawing.Size(121, 17);
+            this.AbsoluteTimeStampCbx.TabIndex = 0;
+            this.AbsoluteTimeStampCbx.Text = "Absolute Timestamp";
+            this.AbsoluteTimeStampCbx.UseVisualStyleBackColor = true;
+            this.AbsoluteTimeStampCbx.CheckedChanged += new System.EventHandler(this.AbsoluteTimeStampCbx_CheckedChanged);
+            // 
+            // CancelButton
+            // 
+            this.CancelButton.Location = new System.Drawing.Point(139, 153);
+            this.CancelButton.Name = "CancelButton";
+            this.CancelButton.Size = new System.Drawing.Size(75, 23);
+            this.CancelButton.TabIndex = 7;
+            this.CancelButton.Text = "&Cancel";
+            this.CancelButton.UseVisualStyleBackColor = true;
+            this.CancelButton.Click += new System.EventHandler(this.CancelButton_Click);
+            // 
+            // OkButton
+            // 
+            this.OkButton.Location = new System.Drawing.Point(41, 153);
+            this.OkButton.Name = "OkButton";
+            this.OkButton.Size = new System.Drawing.Size(75, 23);
+            this.OkButton.TabIndex = 6;
+            this.OkButton.Text = "&OK";
+            this.OkButton.UseVisualStyleBackColor = true;
+            this.OkButton.Click += new System.EventHandler(this.OkButton_Click);
+            // 
+            // Preferences
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(254, 191);
+            this.Controls.Add(this.CancelButton);
+            this.Controls.Add(this.OkButton);
+            this.Controls.Add(this.AbsoluteTimeStampCbx);
+            this.Name = "Preferences";
+            this.Text = "Preferences";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.CheckBox AbsoluteTimeStampCbx;
+        private System.Windows.Forms.Button CancelButton;
+        private System.Windows.Forms.Button OkButton;
+    }
+}

--- a/PSCap/Preferences.cs
+++ b/PSCap/Preferences.cs
@@ -16,6 +16,7 @@ namespace PSCap
         public Preferences()
         {
             InitializeComponent();
+            AbsoluteTimeStampCbx.Checked = Settings.Default.AbsoluteTimeStamp;
         }
 
         private void AbsoluteTimeStampCbx_CheckedChanged(object sender, EventArgs e)

--- a/PSCap/Preferences.cs
+++ b/PSCap/Preferences.cs
@@ -1,0 +1,36 @@
+﻿using PSCap.Properties;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace PSCap
+{
+    public partial class Preferences : Form
+    {
+        public Preferences()
+        {
+            InitializeComponent();
+        }
+
+        private void AbsoluteTimeStampCbx_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Default.AbsoluteTimeStamp = AbsoluteTimeStampCbx.Checked;
+        }
+
+        private void OkButton_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.OK;
+        }
+
+        private void CancelButton_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+        }
+    }
+}

--- a/PSCap/Preferences.resx
+++ b/PSCap/Preferences.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/PSCap/Properties/Settings.Designer.cs
+++ b/PSCap/Properties/Settings.Designer.cs
@@ -37,7 +37,7 @@ namespace PSCap.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool AbsoluteTimeStamp {
             get {
                 return ((bool)(this["AbsoluteTimeStamp"]));

--- a/PSCap/Properties/Settings.Designer.cs
+++ b/PSCap/Properties/Settings.Designer.cs
@@ -8,22 +8,42 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PSCap.Properties
-{
-
-
+namespace PSCap.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string Setting {
+            get {
+                return ((string)(this["Setting"]));
+            }
+            set {
+                this["Setting"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AbsoluteTimeStamp {
+            get {
+                return ((bool)(this["AbsoluteTimeStamp"]));
+            }
+            set {
+                this["AbsoluteTimeStamp"] = value;
             }
         }
     }

--- a/PSCap/Properties/Settings.settings
+++ b/PSCap/Properties/Settings.settings
@@ -1,7 +1,12 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="PSCap.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="Setting" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="AbsoluteTimeStamp" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/PSCap/Properties/Settings.settings
+++ b/PSCap/Properties/Settings.settings
@@ -6,7 +6,7 @@
       <Value Profile="(Default)" />
     </Setting>
     <Setting Name="AbsoluteTimeStamp" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Hello,

I made one additional commit since my post on PSForever to properly set the initial checkbox state according to the setting and made absolute timestamps the default since it is the more user friendly option.

I thought about trying to cache those row values per your TODO on line 564, but it seems to me that could be wasteful of memory for very big capture files and that it might be better to just let the framework handle things via virtualization?

Well, let me know what you think.
